### PR TITLE
FEAT help argument to show aws env vars

### DIFF
--- a/src/SecretsManager/Models/CommandLineOptions.cs
+++ b/src/SecretsManager/Models/CommandLineOptions.cs
@@ -1,0 +1,43 @@
+using CommandLine;
+
+namespace SecretsManager.Models
+{
+    public class CommandLineOptions
+    {
+        [Option('h', "help", Required = false, HelpText = "Display this help message.")]
+        public bool Help { get; set; }
+
+        [Option('v', "version", Required = false, HelpText = "Display version information.")]
+        public bool Version { get; set; }
+
+        [Option('s', "secret-name", Required = false, HelpText = "AWS Secrets Manager secret name to fetch. Overrides configuration.")]
+        public string? SecretName { get; set; }
+
+        [Option('r', "region", Required = false, HelpText = "AWS region (e.g., us-east-1). Overrides configuration.")]
+        public string? Region { get; set; }
+
+        [Option('o', "output-mode", Required = false, HelpText = "Output mode: 'env' (environment variables), 'file' (.env file), or 'both'. Default: both.")]
+        public string? OutputMode { get; set; }
+
+        [Option('e', "env-file", Required = false, HelpText = "Path to the .env file to create/update. Default: .env")]
+        public string? EnvFilePath { get; set; }
+
+        [Option('x', "env-example", Required = false, HelpText = "Path to the .env.example file to parse. Default: .env.example")]
+        public string? EnvExamplePath { get; set; }
+
+        [Option("access-key", Required = false, HelpText = "AWS access key ID. Overrides configuration.")]
+        public string? AccessKey { get; set; }
+
+        [Option("secret-key", Required = false, HelpText = "AWS secret access key. Overrides configuration.")]
+        public string? SecretKey { get; set; }
+
+        [Option('d', "devcontainer", Required = false, HelpText = "Path to devcontainer.json file. Default: .devcontainer/devcontainer.json")]
+        public string? DevContainerPath { get; set; }
+
+        [Option("quiet", Required = false, HelpText = "Suppress non-error output.")]
+        public bool Quiet { get; set; }
+
+        [Option("dry-run", Required = false, HelpText = "Show what would be done without making changes.")]
+        public bool DryRun { get; set; }
+    }
+}

--- a/src/SecretsManager/Program.cs
+++ b/src/SecretsManager/Program.cs
@@ -1,4 +1,6 @@
 ﻿using Amazon.SecretsManager;
+using CommandLine;
+using CommandLine.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -6,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SecretsManager.Models;
 using SecretsManager.Services;
+using System.Reflection;
 
 namespace SecretsManager
 {
@@ -13,13 +16,37 @@ namespace SecretsManager
     {
         static async Task Main(string[] args)
         {
-            var host = CreateHostBuilder(args).Build();
+            // Parse command line arguments
+            var parser = new Parser(with => with.HelpWriter = null);
+            var parserResult = parser.ParseArguments<CommandLineOptions>(args);
+
+            await parserResult.WithParsedAsync(async options =>
+            {
+                // Handle help
+                if (options.Help)
+                {
+                    DisplayHelp(parserResult);
+                    return;
+                }
+
+                // Handle version
+                if (options.Version)
+                {
+                    DisplayVersion();
+                    return;
+                }
+
+                // Build and run the application with parsed options
+                var host = CreateHostBuilder(args, options).Build();
             
             try
             {
                 var logger = host.Services.GetRequiredService<ILogger<Program>>();
                 var config = host.Services.GetRequiredService<IOptions<SecretsManagerConfig>>().Value;
-                logger.LogInformation("Starting Secrets Manager application");
+                var cmdOptions = host.Services.GetRequiredService<CommandLineOptions>();
+                
+                if (!cmdOptions.Quiet)
+                    logger.LogInformation("Starting Secrets Manager application");
 
                 var allSecrets = new Dictionary<string, string>();
 
@@ -28,8 +55,13 @@ namespace SecretsManager
                 var devContainerConfig = await devContainerService.LoadDevContainerConfigAsync();
                 if (devContainerConfig != null)
                 {
-                    logger.LogInformation("Processing DevContainer secrets...");
-                    await devContainerService.ProcessDevContainerSecretsAsync(devContainerConfig);
+                    if (!cmdOptions.Quiet)
+                        logger.LogInformation("Processing DevContainer secrets...");
+                    
+                    if (!cmdOptions.DryRun)
+                        await devContainerService.ProcessDevContainerSecretsAsync(devContainerConfig);
+                    else if (!cmdOptions.Quiet)
+                        Console.WriteLine("[DRY RUN] Would process DevContainer secrets");
                 }
 
                 // Process .env.example secrets (if exists) - INDEPENDENT OF DEVCONTAINER
@@ -37,8 +69,26 @@ namespace SecretsManager
                 var envExampleVars = await envFileService.LoadEnvExampleFileAsync(config.EnvExamplePath);
                 if (envExampleVars != null && envExampleVars.Any())
                 {
-                    logger.LogInformation("Processing .env.example secrets...");
-                    var processedSecrets = await envFileService.ProcessEnvFileSecretsAsync(envExampleVars);
+                    if (!cmdOptions.Quiet)
+                        logger.LogInformation("Processing .env.example secrets...");
+                    
+                    Dictionary<string, string> processedSecrets;
+                    if (!cmdOptions.DryRun)
+                    {
+                        processedSecrets = await envFileService.ProcessEnvFileSecretsAsync(envExampleVars);
+                    }
+                    else
+                    {
+                        processedSecrets = new Dictionary<string, string>();
+                        if (!cmdOptions.Quiet)
+                        {
+                            Console.WriteLine("[DRY RUN] Would process the following .env.example secrets:");
+                            foreach (var arn in envExampleVars.Where(kv => kv.Value.StartsWith("${arn:")))
+                            {
+                                Console.WriteLine($"  {arn.Key}: {arn.Value}");
+                            }
+                        }
+                    }
                     
                     // Merge with collected secrets
                     foreach (var secret in processedSecrets)
@@ -49,8 +99,16 @@ namespace SecretsManager
                         if (config.OutputMode == OutputMode.EnvironmentVariables || 
                             config.OutputMode == OutputMode.Both)
                         {
-                            Environment.SetEnvironmentVariable(secret.Key, secret.Value);
-                            logger.LogInformation("Set environment variable {Key} from .env.example", secret.Key);
+                            if (!cmdOptions.DryRun)
+                            {
+                                Environment.SetEnvironmentVariable(secret.Key, secret.Value);
+                                if (!cmdOptions.Quiet)
+                                    logger.LogInformation("Set environment variable {Key} from .env.example", secret.Key);
+                            }
+                            else if (!cmdOptions.Quiet)
+                            {
+                                Console.WriteLine($"[DRY RUN] Would set environment variable: {secret.Key}");
+                            }
                         }
                     }
                 }
@@ -59,42 +117,70 @@ namespace SecretsManager
                 if ((config.OutputMode == OutputMode.EnvFile || config.OutputMode == OutputMode.Both) && 
                     allSecrets.Any())
                 {
-                    await envFileService.WriteEnvFileAsync(allSecrets, config.EnvFilePath);
+                    if (!cmdOptions.DryRun)
+                    {
+                        await envFileService.WriteEnvFileAsync(allSecrets, config.EnvFilePath);
+                    }
+                    else if (!cmdOptions.Quiet)
+                    {
+                        Console.WriteLine($"[DRY RUN] Would write .env file to: {config.EnvFilePath}");
+                        Console.WriteLine("[DRY RUN] Would write the following variables:");
+                        foreach (var secret in allSecrets)
+                        {
+                            Console.WriteLine($"  {secret.Key}={MaskSecret(secret.Value)}");
+                        }
+                    }
                 }
 
                 // Continue with existing app secrets processing
                 var secretsService = host.Services.GetRequiredService<ISecretsService>();
-                var secrets = await secretsService.GetSecretsAsync();
-
-                logger.LogInformation("Successfully retrieved secrets from AWS Secrets Manager");
+                AppSecrets? secrets = null;
+                
+                if (!cmdOptions.DryRun)
+                {
+                    secrets = await secretsService.GetSecretsAsync();
+                    if (!cmdOptions.Quiet)
+                        logger.LogInformation("Successfully retrieved secrets from AWS Secrets Manager");
+                }
+                else if (!cmdOptions.Quiet)
+                {
+                    Console.WriteLine($"[DRY RUN] Would fetch secret: {config.SecretName} from region: {host.Services.GetRequiredService<IOptions<AwsConfig>>().Value.Region}");
+                }
                 
                 // Display the retrieved secrets (in a real application, you would use these secrets)
-                Console.WriteLine("Retrieved Application Secrets:");
-                Console.WriteLine($"Database URL: {secrets.DatabaseUrl}");
-                Console.WriteLine($"API Key: {MaskSecret(secrets.ApiKey)}");
-                Console.WriteLine($"JWT Secret: {MaskSecret(secrets.JwtSecret)}");
-                Console.WriteLine($"Redis URL: {secrets.RedisUrl}");
+                if (!cmdOptions.Quiet && secrets != null)
+                {
+                    Console.WriteLine("Retrieved Application Secrets:");
+                    Console.WriteLine($"Database URL: {secrets.DatabaseUrl}");
+                    Console.WriteLine($"API Key: {MaskSecret(secrets.ApiKey)}");
+                    Console.WriteLine($"JWT Secret: {MaskSecret(secrets.JwtSecret)}");
+                    Console.WriteLine($"Redis URL: {secrets.RedisUrl}");
+                }
 
                 // Display any environment variables that were set
-                Console.WriteLine("\nEnvironment Variables Set:");
-                var envVars = Environment.GetEnvironmentVariables();
-                foreach (var key in envVars.Keys)
+                if (!cmdOptions.Quiet && !cmdOptions.DryRun)
                 {
-                    var keyStr = key.ToString();
-                    if (keyStr != null && (keyStr.Contains("TOKEN") || keyStr.Contains("SECRET") || keyStr.Contains("KEY") || allSecrets.ContainsKey(keyStr)))
+                    Console.WriteLine("\nEnvironment Variables Set:");
+                    var envVars = Environment.GetEnvironmentVariables();
+                    foreach (var key in envVars.Keys)
                     {
-                        var value = envVars[key]?.ToString() ?? "";
-                        Console.WriteLine($"{keyStr}: {MaskSecret(value)}");
+                        var keyStr = key.ToString();
+                        if (keyStr != null && (keyStr.Contains("TOKEN") || keyStr.Contains("SECRET") || keyStr.Contains("KEY") || allSecrets.ContainsKey(keyStr)))
+                        {
+                            var value = envVars[key]?.ToString() ?? "";
+                            Console.WriteLine($"{keyStr}: {MaskSecret(value)}");
+                        }
                     }
                 }
 
                 // Display .env file status
-                if (config.OutputMode == OutputMode.EnvFile || config.OutputMode == OutputMode.Both)
+                if (!cmdOptions.Quiet && !cmdOptions.DryRun && (config.OutputMode == OutputMode.EnvFile || config.OutputMode == OutputMode.Both))
                 {
                     Console.WriteLine($"\n.env file written to: {config.EnvFilePath}");
                 }
 
-                logger.LogInformation("Application completed successfully");
+                if (!cmdOptions.Quiet)
+                    logger.LogInformation("Application completed successfully");
             }
             catch (Exception ex)
             {
@@ -103,14 +189,52 @@ namespace SecretsManager
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
+            });
+
+            // Handle parsing errors
+            await parserResult.WithNotParsedAsync(async errors =>
+            {
+                if (errors.IsHelp() || errors.IsVersion())
+                {
+                    DisplayHelp(parserResult);
+                }
+                else
+                {
+                    Console.WriteLine("Error parsing command line arguments.");
+                    DisplayHelp(parserResult);
+                    Environment.Exit(1);
+                }
+            });
         }
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
+        static IHostBuilder CreateHostBuilder(string[] args, CommandLineOptions options) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
                     config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
                     config.AddEnvironmentVariables();
+                    
+                    // Add command line options as configuration
+                    var cmdLineConfig = new Dictionary<string, string?>();
+                    if (!string.IsNullOrEmpty(options.SecretName))
+                        cmdLineConfig["SecretsManager:SecretName"] = options.SecretName;
+                    if (!string.IsNullOrEmpty(options.Region))
+                        cmdLineConfig["AWS:Region"] = options.Region;
+                    if (!string.IsNullOrEmpty(options.AccessKey))
+                        cmdLineConfig["AWS:AccessKey"] = options.AccessKey;
+                    if (!string.IsNullOrEmpty(options.SecretKey))
+                        cmdLineConfig["AWS:SecretKey"] = options.SecretKey;
+                    if (!string.IsNullOrEmpty(options.OutputMode))
+                        cmdLineConfig["SecretsManager:OutputMode"] = options.OutputMode;
+                    if (!string.IsNullOrEmpty(options.EnvFilePath))
+                        cmdLineConfig["SecretsManager:EnvFilePath"] = options.EnvFilePath;
+                    if (!string.IsNullOrEmpty(options.EnvExamplePath))
+                        cmdLineConfig["SecretsManager:EnvExamplePath"] = options.EnvExamplePath;
+                    if (!string.IsNullOrEmpty(options.DevContainerPath))
+                        cmdLineConfig["SecretsManager:DevContainerPath"] = options.DevContainerPath;
+                        
+                    if (cmdLineConfig.Any())
+                        config.AddInMemoryCollection(cmdLineConfig!);
                 })
                 .ConfigureServices((context, services) =>
                 {
@@ -177,6 +301,9 @@ namespace SecretsManager
                     services.AddScoped<ISecretsService, AwsSecretsService>();
                     services.AddScoped<IDevContainerService, DevContainerService>();
                     services.AddScoped<IEnvFileService, EnvFileService>();
+                    
+                    // Register command line options
+                    services.AddSingleton(options);
                 })
                 .ConfigureLogging(logging =>
                 {
@@ -190,6 +317,78 @@ namespace SecretsManager
                 return "****";
             
             return secret.Substring(0, 2) + new string('*', secret.Length - 4) + secret.Substring(secret.Length - 2);
+        }
+
+        private static void DisplayHelp(ParserResult<CommandLineOptions> result)
+        {
+            Console.WriteLine("Universal Secrets Manager");
+            Console.WriteLine("A .NET application that fetches secrets from AWS Secrets Manager\n");
+            
+            var helpText = CommandLine.Text.HelpText.AutoBuild(result, h =>
+            {
+                h.AdditionalNewLineAfterOption = false;
+                h.MaximumDisplayWidth = 120;
+                h.AutoHelp = false;
+                h.AutoVersion = false;
+                return CommandLine.Text.HelpText.DefaultParsingErrorsHandler(result, h);
+            }, e => e);
+            
+            Console.WriteLine(helpText);
+            
+            Console.WriteLine("\nEnvironment Variables:");
+            Console.WriteLine("  AWS Credentials:");
+            Console.WriteLine("    AWS_ACCESS_KEY_ID               - AWS access key ID");
+            Console.WriteLine("    AWS_SECRET_ACCESS_KEY           - AWS secret access key");
+            Console.WriteLine("    AWS_DEFAULT_REGION              - Default AWS region (e.g., us-east-1)");
+            Console.WriteLine("    AWS_REGION                      - Alternative region variable\n");
+            
+            Console.WriteLine("  .NET Configuration Style:");
+            Console.WriteLine("    AWS__AccessKey                  - AWS access key ID (.NET config format)");
+            Console.WriteLine("    AWS__SecretKey                  - AWS secret access key (.NET config format)");
+            Console.WriteLine("    AWS__Region                     - AWS region (.NET config format)\n");
+            
+            Console.WriteLine("  Application Settings:");
+            Console.WriteLine("    SecretsManager__SecretName      - Override secret name from config");
+            Console.WriteLine("    SecretsManager__OutputMode      - Override output mode (env/file/both)");
+            Console.WriteLine("    SecretsManager__EnvFilePath     - Override .env file path");
+            Console.WriteLine("    SecretsManager__EnvExamplePath  - Override .env.example path\n");
+            
+            Console.WriteLine("Examples:");
+            Console.WriteLine("  Fetch secrets using configuration:");
+            Console.WriteLine("    ./SecretsManager\n");
+            Console.WriteLine("  Fetch a specific secret:");
+            Console.WriteLine("    ./SecretsManager --secret-name my-app-secrets --region us-west-2\n");
+            Console.WriteLine("  Use explicit AWS credentials:");
+            Console.WriteLine("    ./SecretsManager --access-key AKIAIOSFODNN7EXAMPLE --secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n");
+            Console.WriteLine("  Use environment variables:");
+            Console.WriteLine("    export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE");
+            Console.WriteLine("    export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+            Console.WriteLine("    export AWS_DEFAULT_REGION=us-west-2");
+            Console.WriteLine("    ./SecretsManager\n");
+            Console.WriteLine("  Override secret name via environment:");
+            Console.WriteLine("    export SecretsManager__SecretName=my-app-secrets");
+            Console.WriteLine("    ./SecretsManager\n");
+            Console.WriteLine("  Create .env file only:");
+            Console.WriteLine("    ./SecretsManager --output-mode file --env-file ./config/.env\n");
+            Console.WriteLine("  Parse custom .env.example:");
+            Console.WriteLine("    ./SecretsManager --env-example ./config/.env.example\n");
+            
+            Console.WriteLine("Configuration Priority (highest to lowest):");
+            Console.WriteLine("  1. Command line arguments");
+            Console.WriteLine("  2. Environment variables");
+            Console.WriteLine("  3. appsettings.json");
+            Console.WriteLine("  4. AWS SDK credential chain (IAM roles, etc.)\n");
+        }
+
+        private static void DisplayVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var version = assembly.GetName().Version?.ToString() ?? "1.0.0";
+            var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? version;
+            
+            Console.WriteLine($"Universal Secrets Manager v{informationalVersion}");
+            Console.WriteLine($"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+            Console.WriteLine($"Platform: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");
         }
     }
 }

--- a/src/SecretsManager/SecretsManager.csproj
+++ b/src/SecretsManager/SecretsManager.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.0.4" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add command-line argument handling and configuration options to the Secrets Manager application, allowing the display of help and version information, and introducing options for fetching AWS secrets, handling output modes, and supporting dry runs.

### Why are these changes being made?

These changes enhance the usability and flexibility of the Secrets Manager application by enabling users to configure its behavior directly via command-line arguments as well as providing help and version commands. This approach allows for clearer definitions of what the application does, simplifies usage instructions, and offers a new feature set like dry run capability and output mode customization. Additionally, it introduces improved user communication through selective logging with a quiet mode and the display of current configuration settings related to AWS.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive command-line interface with support for flags such as help, version, quiet mode, dry run, and AWS-specific parameters.
  * Added options for output configuration, including output mode and environment file paths.
  * Users can now run the application in "quiet" or "dry run" modes to suppress output or preview actions without making changes.

* **Enhancements**
  * Improved help and version display with detailed usage instructions and environment variable information.
  * Enhanced error handling for command-line argument parsing.

* **Chores**
  * Added a new dependency for command-line argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->