### PR TITLE
FIX runtime error when invoking help cmd arg

### DIFF
--- a/src/SecretsManager/Models/CommandLineOptions.cs
+++ b/src/SecretsManager/Models/CommandLineOptions.cs
@@ -4,6 +4,11 @@ namespace SecretsManager.Models
 {
     public class CommandLineOptions
     {
+        public CommandLineOptions()
+        {
+            // Default constructor required by CommandLineParser
+        }
+
         [Option('h', "help", Required = false, HelpText = "Display this help message.")]
         public bool Help { get; set; }
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a default constructor to the `CommandLineOptions` class to prevent a runtime error when invoking the help command argument.

### Why are these changes being made?

The CommandLineParser requires a default constructor to function properly. Without it, invoking the help command resulted in a runtime error, so adding an explicit default constructor resolves this issue.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal updates to improve compatibility with command-line parsing. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->