### PR TITLE
FIX help cmdline argument working

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,0 +1,27 @@
+# Use .NET SDK for building
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+WORKDIR /app
+
+# Copy solution and project files
+COPY *.sln ./
+COPY src/SecretsManager/*.csproj ./src/SecretsManager/
+COPY src/SecretsManager.Tests/*.csproj ./src/SecretsManager.Tests/
+
+# Restore dependencies
+RUN dotnet restore
+
+# Copy source code
+COPY . .
+
+# Build and publish single-file executable without trimming
+RUN dotnet publish src/SecretsManager/SecretsManager.csproj \
+    -c Release \
+    -r linux-x64 \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=false \
+    -o /app/dist
+
+# Final stage - copy the binary
+FROM scratch AS export
+COPY --from=build-env /app/dist/SecretsManager /SecretsManager

--- a/src/SecretsManager/Program.cs
+++ b/src/SecretsManager/Program.cs
@@ -17,27 +17,25 @@ namespace SecretsManager
         static async Task Main(string[] args)
         {
             // Parse command line arguments
-            var parser = new Parser(with => with.HelpWriter = null);
-            var parserResult = parser.ParseArguments<CommandLineOptions>(args);
-
-            await parserResult.WithParsedAsync(async options =>
+            var result = Parser.Default.ParseArguments<CommandLineOptions>(args);
+            
+            // If parsing failed (help, version, or error), Parser.Default handles it automatically
+            if (result.Tag == ParserResultType.NotParsed)
             {
-                // Handle help
-                if (options.Help)
-                {
-                    DisplayHelp(parserResult);
-                    return;
-                }
+                return;
+            }
+            
+            var options = result.Value;
+            
+            // Handle version explicitly if needed
+            if (options.Version)
+            {
+                DisplayVersion();
+                return;
+            }
 
-                // Handle version
-                if (options.Version)
-                {
-                    DisplayVersion();
-                    return;
-                }
-
-                // Build and run the application with parsed options
-                var host = CreateHostBuilder(args, options).Build();
+            // Build and run the application with parsed options
+            var host = CreateHostBuilder(args, options).Build();
             
             try
             {
@@ -189,22 +187,6 @@ namespace SecretsManager
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-            });
-
-            // Handle parsing errors
-            await parserResult.WithNotParsedAsync(async errors =>
-            {
-                if (errors.IsHelp() || errors.IsVersion())
-                {
-                    DisplayHelp(parserResult);
-                }
-                else
-                {
-                    Console.WriteLine("Error parsing command line arguments.");
-                    DisplayHelp(parserResult);
-                    Environment.Exit(1);
-                }
-            });
         }
 
         static IHostBuilder CreateHostBuilder(string[] args, CommandLineOptions options) =>

--- a/src/SecretsManager/SecretsManager.csproj
+++ b/src/SecretsManager/SecretsManager.csproj
@@ -12,8 +12,7 @@
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">linux-x64</RuntimeIdentifier>
     
     <!-- Optimization settings -->
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>link</TrimMode>
+    <PublishTrimmed>false</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
     
     <!-- Include native libraries in single file -->


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Update Dockerfile to use .NET SDK 7.0, revise command-line parsing logic in `Program.cs` to improve handling of help and version arguments, and modify build settings in `SecretsManager.csproj` to disable trimming.

### Why are these changes being made?

The changes to the Dockerfile ensure compatibility with the latest .NET SDK for building, the refactor of `Program.cs` optimizes argument parsing for better clarity and reduces code redundancy, while the csproj modifications prevent trimming issues that could impact functionality, especially when deploying as a single-file executable.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new Dockerfile to support building and publishing the application as a self-contained, single-file executable.
  * Updated project settings to disable publish trimming for improved compatibility.

* **Refactor**
  * Simplified command-line argument parsing for a more streamlined startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->